### PR TITLE
Fix build errors

### DIFF
--- a/src/em/Parser.cpp
+++ b/src/em/Parser.cpp
@@ -1,5 +1,6 @@
 #include "Parser.h"
 
+#include <algorithm>
 #include <unordered_set>
 
 #include "ast/Program.h"

--- a/src/em/values/sets/MaterialSetValue.h
+++ b/src/em/values/sets/MaterialSetValue.h
@@ -8,11 +8,11 @@
 
 namespace em::values::sets {
   struct ValuePtrHash {
-    constexpr std::size_t operator()(const std::shared_ptr<Value>& value) const { return value->hash(); }
+    std::size_t operator()(const std::shared_ptr<Value>& value) const { return value->hash(); }
   };
 
   struct ValuePtrEq {
-    constexpr bool operator()(const std::shared_ptr<Value>& a, const std::shared_ptr<Value>& b) const {
+    bool operator()(const std::shared_ptr<Value>& a, const std::shared_ptr<Value>& b) const {
       return *a == *b;
     }
   };


### PR DESCRIPTION
## Summary

Currently the build is failing when compiling against C++17 because virtual functions can't be `constexpr` and because there is a missing import. This change addresses that.

## Testing

GitHub workflow.

## TODO

Investigate why the build was succeeding locally.